### PR TITLE
feat(sourcemap): add relative path sourcemap support and republish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 test/output/*
+.vscode

--- a/index.js
+++ b/index.js
@@ -100,6 +100,17 @@ module.exports = function(input, inputMap) {
 			});
 			return;
 		}
+		// try to resolve relative paths in source paths and truncate the cwd
+        var cwd = process.cwd();
+        var shortContext = context.substr(0, cwd.length) === cwd
+            ? context.substr(cwd.length + 1)
+            : context;
+        map.sources = map.sources.map(function(s) {
+            var resolvedPath = path.resolve(shortContext, s);
+            return resolvedPath.substr(0, cwd.length) === cwd
+                ? resolvedPath.substr(cwd.length + 1)
+                : resolvedPath;
+        })
 		callback(null, input.replace(match[0], ''), map);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "source-map-loader",
+  "name": "@widen/source-map-loader",
   "version": "0.2.3",
   "author": "Tobias Koppers @sokra",
   "description": "extracts inlined source map and offers it to webpack",
@@ -15,7 +15,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/webpack/source-map-loader.git"
+    "url": "git+https://github.com/widen/source-map-loader"
+  },
+  "publishConfig": {
+    "registry": "http://widen.jfrog.io/widen/api/npm/npm-virtual/"
   },
   "licenses": [
     {


### PR DESCRIPTION
This PR adds relative path resolution for sourcemaps loaded in.

Babel currently produces sourcemap paths with relative syntax by default.